### PR TITLE
CS-1686 Use LAX sameSite policy by default

### DIFF
--- a/server/sonar-server/src/main/java/org/sonar/server/app/EmbeddedTomcat.java
+++ b/server/sonar-server/src/main/java/org/sonar/server/app/EmbeddedTomcat.java
@@ -62,7 +62,7 @@ class EmbeddedTomcat {
     try {
       tomcat.start();
       // Set sameSite attribute in default Cookie Processor created during Tomcat context initialization.
-      ((CookieProcessorBase) webappContext.getCookieProcessor()).setSameSiteCookies(SameSiteCookies.STRICT.getValue());
+      ((CookieProcessorBase) webappContext.getCookieProcessor()).setSameSiteCookies(SameSiteCookies.LAX.getValue());
       new TomcatStartupLogs(Loggers.get(getClass())).log(tomcat);
     } catch (LifecycleException e) {
       Loggers.get(EmbeddedTomcat.class).error("Fail to start web server", e);


### PR DESCRIPTION
Use LAX sameSite policy by default because CSRF cookies should be accessible during SSO authentication